### PR TITLE
return syntax attribute message to function caller

### DIFF
--- a/README
+++ b/README
@@ -18,3 +18,7 @@ This can be helpfull both developing syntax files, and for determining what some
 Recommended use with a mapping such as:
 
   map -a	:call SyntaxAttr()<CR>
+  
+If you want to copy the syntax information into register "a" for using in your own syntax files or colorschemes, you could map as follows:
+
+noremap <S-C-M-F12> :let @a = SyntaxAttr()<CR>

--- a/plugin/SyntaxAttr.vim
+++ b/plugin/SyntaxAttr.vim
@@ -62,4 +62,6 @@ function! SyntaxAttr()
      endif
      echo message
      echohl None
+     
+     return message
 endfunction


### PR DESCRIPTION
I've found it's useful to be able to copy the Syntax Attributes to a register if required, for my own syntax highlighting or colorschemes, for example.
One-line change to make this possible: return the syntax attributes to the function caller.